### PR TITLE
update ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
       #  -----  setup uv and load cache   -----
       #----------------------------------------------
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -67,7 +67,7 @@ jobs:
       #  -----  setup uv and load cache   -----
       #----------------------------------------------
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -95,7 +95,7 @@ jobs:
       #  -----  setup uv and load cache   -----
       #----------------------------------------------
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.6.10"
+  UV_VERSION: "0.6.17"
 
 # If new code is pushed to a PR branch, then cancel in progress workflows for that PR. Ensures that
 # we don't waste CI time, and returns results quicker https://github.com/jonhoo/rust-ci-conf/pull/5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.5.15"
+  UV_VERSION: "0.6.10"
 
 # If new code is pushed to a PR branch, then cancel in progress workflows for that PR. Ensures that
 # we don't waste CI time, and returns results quicker https://github.com/jonhoo/rust-ci-conf/pull/5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
   merge_group:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.6.10"
+  UV_VERSION: "0.6.17"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.5.15"
+  UV_VERSION: "0.6.10"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       #  -----  setup uv and load cache   -----
       #----------------------------------------------
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,7 +6,8 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "7 7 * * *"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -61,7 +61,7 @@ jobs:
     # Cargo semver rules (i.e cargo does not update to a new major version unless explicitly told
     # to).
     runs-on: ubuntu-latest
-    name: ubuntu / 3.12 / updates work
+    name: ubuntu / 3.13 / updates work
     # There's no point running this if no uv.lock was checked in in the first place, since we'd
     # just redo what happened in the regular test job. Unfortunately, hashFiles only works in if on
     # steps, so we repeat it.
@@ -77,11 +77,11 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
 
-      - name: Install 3.12
+      - name: Install 3.13
         if: hashFiles('uv.lock') != ''
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: uv sync --dev --upgrade
         if: hashFiles('uv.lock') != ''

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,7 +18,7 @@ concurrency:
 name: rolling
 
 env:
-  UV_VERSION: "0.5.15"
+  UV_VERSION: "0.6.10"
 
 jobs:
   # https://twitter.com/mycoliza/status/1571295690063753218

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -73,7 +73,7 @@ jobs:
 
       - name: Set up uv
         if: hashFiles('uv.lock') != ''
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,7 +19,7 @@ concurrency:
 name: rolling
 
 env:
-  UV_VERSION: "0.6.10"
+  UV_VERSION: "0.6.17"
 
 jobs:
   # https://twitter.com/mycoliza/status/1571295690063753218

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
   schedule:
     - cron: "7 7 * * *"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.5.15"
+  UV_VERSION: "0.6.10"
 
 jobs:
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   MINIMUM_PYTHON_VERSION: "3.9"
-  UV_VERSION: "0.6.10"
+  UV_VERSION: "0.6.17"
 
 jobs:
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: true
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -108,7 +108,7 @@ jobs:
           submodules: true
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
@@ -158,7 +158,7 @@ jobs:
           submodules: true
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
   merge_group:
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # running-stats
 
-[![Build & Publish](https://github.com/kod-kristoff/running-stats-py/workflows/Build%20&%20Publish/badge.svg?branch=master)](https://github.com/kod-kristoff/running-stats-py/actions)
-[![codecov](https://codecov.io/gh/kod-kristoff/running-stats-py/g/branch/master/graph/badge.svg)](https://codecov.io/gh/kod-kristoff/running-stats-py)
-[![Maintainability](https://api.codeclimate.com/v1/badges/07f28a8ed2f04bc62429/maintainability)](https://codeclimate.com/github/kod-kristoff/running-stats-py/maintainability)
+[![PyPI version](https://img.shields.io/pypi/v/running-stats.svg?style=flat-square&colorB=dfb317)](https://pypi.org/project/running-stats/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/running-stats)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/running-stats)](https://pypi.org/project/running-stats/)
+ [![Docs](https://img.shields.io/badge/docs-here-red.svg?style=flat-square)](https://kod-kristoff.github.io/running-stats-py/)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)
+
+[![Code Coverage](https://codecov.io/gh/kod-kristoff/running-stats-py/g/branch/master/graph/badge.svg)](https://codecov.io/gh/kod-kristoff/running-stats-py)
+[![Maintainability](https://qlty.sh/badges/6581c0f9-f9d8-4104-ba06-f8e61a4f3677/maintainability.svg)](https://qlty.sh/gh/kod-kristoff/projects/running-stats-py)
+
+[![CI(check)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/check.yml/badge.svg)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/check.yml)
+[![CI(release)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/release.yml/badge.svg)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/release.yml)
+[![CI(scheduled)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/scheduled.yml/badge.svg)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/scheduled.yml)
+[![CI(test)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/test.yml/badge.svg)](https://github.com/kod-kristoff/running-stats-py/actions/workflows/test.yml)
 
 Inspired by [John D. Cook's blog](https://www.johndcook.com/blog/skewness_kurtosis/)
-## usage
 
+## Usage


### PR DESCRIPTION
- **ci: bump python version to 3.13 in update**
- **ci: bump uv to 0.6.10**
- **ci: use better mergeable format**
- **ci: bump uv version to 0.6.17**
- **ci: bump setup-uv to v6**
- **ci: also run for main branch**

## Summary by Sourcery

Update CI workflows by bumping dependency versions and adding the `master` branch to triggers.

CI:
- Bump `uv` version to `0.6.17`.
- Bump `astral-sh/setup-uv` action to `v6`.
- Bump Python version to `3.13` in the scheduled dependency update job.
- Trigger workflows on pushes to the `master` branch in addition to `main`.